### PR TITLE
Fixes no-name spectator issue

### DIFF
--- a/ParkourGame/Content/ThirdPersonCPP/Blueprints/WidgetLobbyScreen.uasset
+++ b/ParkourGame/Content/ThirdPersonCPP/Blueprints/WidgetLobbyScreen.uasset
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:13f6dc764ad2122f5c36c984ed662599d73a68ae626310641419c0ab730c88ba
-size 126451
+oid sha256:bb81a6adab7d0ab2db1c08e9e26dc5d01f942f35955adde4dd92d6436675983a
+size 148996

--- a/ParkourGame/Content/ThirdPersonCPP/Maps/entryMap.umap
+++ b/ParkourGame/Content/ThirdPersonCPP/Maps/entryMap.umap
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:7a52a46dfaf4cd71ee5239e7fc301bc26df998c405f68260e9b294e2fc39e383
+oid sha256:21c600a4eb98cca40d715593a0b84684f9202ab32686f32f5158e7b0f0dc1e8d
 size 53995

--- a/ParkourGame/Content/ThirdPersonCPP/Maps/entryMap_BuiltData.uasset
+++ b/ParkourGame/Content/ThirdPersonCPP/Maps/entryMap_BuiltData.uasset
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:e0c0c8155c12103773448e39a7273e7a49e102c5f3eb737f25c50d255a9c6693
-size 50653
+oid sha256:770ad9b222ff3ddeac448d5c702cf63ff284f0ed1fa2345cee90a865c6f3493b
+size 51109


### PR DESCRIPTION
This commit fixes the no-name spectator issue and adds error handling
for players who don't enter a name at the lobby screen.

Fixes #89 