### PR TITLE
Character: fixed ragdoll event not triggering

### DIFF
--- a/ParkourGame/Content/ThirdPersonCPP/Blueprints/ThirdPersonCharacter.uasset
+++ b/ParkourGame/Content/ThirdPersonCPP/Blueprints/ThirdPersonCharacter.uasset
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:a4807084d12b03960d7f88ca4c229d4c6fb4127e6e6479dd9146d0c0cfff57a0
-size 1052302
+oid sha256:29e5846df7e10d4f5979660ed20e1b263a3ce5bd9b0750220fe2914f2ffdbf32
+size 1038864


### PR DESCRIPTION
Also edits the values for collisions, these
are not final

Fixes #96 (commit wrongly states #94)