### PR TITLE
Character: Tackle not registering sometimes

### DIFF
--- a/ParkourGame/Content/Mannequin/Animations/ThirdPerson_AnimBP.uasset
+++ b/ParkourGame/Content/Mannequin/Animations/ThirdPerson_AnimBP.uasset
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:285c09dc374ea4502cf25bf0e7fdae60afe30f08114d4c7decce0b1183f86739
-size 754764
+oid sha256:7ce3b486ace2cf0b85892f1ef9a11792700ab835e0ea470a4397074b3f957cc9
+size 755781

--- a/ParkourGame/Content/ThirdPersonCPP/Blueprints/ThirdPersonCharacter.uasset
+++ b/ParkourGame/Content/ThirdPersonCPP/Blueprints/ThirdPersonCharacter.uasset
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:29e5846df7e10d4f5979660ed20e1b263a3ce5bd9b0750220fe2914f2ffdbf32
-size 1038864
+oid sha256:791442d84ee9c247ea3f559fad9d3e36d3518b44ebb39bd5a386a3bddc913c7e
+size 1056384


### PR DESCRIPTION
Added a new hitbox for the arms while tackling
15ms delay added onto end of tackle animation
(character is still considered to be tackling
during this delay, improving responsiveness)

Fixes #94