### PR TITLE
Fix slide frame rate dependency

### DIFF
--- a/ParkourGame/Content/ThirdPersonCPP/Blueprints/ThirdPersonCharacter.uasset
+++ b/ParkourGame/Content/ThirdPersonCPP/Blueprints/ThirdPersonCharacter.uasset
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:1500be6b46997b1c7f71dd0030fec2733a4b748469ecddd3b56913148812ebca
-size 1163925
+oid sha256:12670c7768432e3a8ff0481e03bee8bd62e88f646cd35cfe2188934eb5110b40
+size 1192474


### PR DESCRIPTION
# Frame Rate Independent Slide

- Sliding move is now frame rate independent and will reduce speed by 80%
per second.

### Further notes:
- Feel free to change the parameters of the slide to fit your needs. Initial multiplier, decelleration co-efficient and impact detection can all be changed.

Fixes #133 